### PR TITLE
Se aceptan los.py en el packager

### DIFF
--- a/enebootools/packager/pkgjoiner.py
+++ b/enebootools/packager/pkgjoiner.py
@@ -112,7 +112,7 @@ def createpkg(iface, modulefolder):
     filelines = []
     shasum = ""
     ignored_ext = set([])
-    load_ext = set(['.qs', '.mtd', '.ts', '.ar', '.kut', '.qry', '.ui', '.xml', '.xpm'])
+    load_ext = set(['.qs', '.mtd', '.ts', '.ar', '.kut', '.qry', '.ui', '.xml', '.xpm', '.py'])
     for folder, module in zip(file_folders,modnames):
         fpath = os.path.join(modulefolder,folder)
         files = find_files(fpath)

--- a/enebootools/packager/pkgsplitter.py
+++ b/enebootools/packager/pkgsplitter.py
@@ -15,6 +15,7 @@ def extpath(name):
         '.pgsql': 'pgsql',
         '.qry': 'queries',
         '.qs': 'scripts',
+        '.py': 'scripts',
         '.qso': 'binscripts',
         '.sql': 'pgsql',
         '.ts': 'translations',


### PR DESCRIPTION
Al generar / extraer un fichero eneboopkg, se aceptan los ficheros .py